### PR TITLE
Fix branching on `$value` in Command::maybePushArgument method

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -49,10 +49,11 @@ class Command
   {
     $key = "--$key";
 
-    match ($value) {
-      true => $this->arguments->push($key),
-      default => $this->arguments->push($key, $value)
-    };
+    if ($value === true) {
+      $this->arguments->push($key);
+    } else if ($value) {
+      $this->arguments->push($key, $value);
+    }
   }
 
   protected function prepareOptionalArguments(): void

--- a/src/Command.php
+++ b/src/Command.php
@@ -49,7 +49,7 @@ class Command
   {
     $key = "--$key";
 
-    if ($value === true) {
+    if (is_bool($value) && $value) {
       $this->arguments->push($key);
     } else if ($value) {
       $this->arguments->push($key, $value);


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**What is the new behavior?**
Fix bug related to checks on a true/thruty value.

**Does this PR introduce a breaking change?**
No

**Other information:**
After updating a project to laravel 9 and using `dev-main` weasyprint package version for compatibility, pdf could not render fonts properly. 
Checking every change on `dev-main`, we found out the thing that was causing the breaking behavior was a match in Command.php at maybePushArgument method: https://github.com/mikerockett/weasyprint/blob/1c3e4a9328199c5c5594bba6212565849309846d/src/Command.php#L52
branch `6.x` version checks for true values and thruty values leaving out falsy values:
```php
if ($value === true) {
      $this->arguments->push($key);
} else if ($value) {
      $this->arguments->push($key, $value);
}
```
`dev-main` version with match threats every value that isn't strictly boolean true equally.
Our proposed change restores previous behavior.